### PR TITLE
Added -sprint and -showIssuesRefs

### DIFF
--- a/JiraAnalytics/Common/JiraSearchRequest.go
+++ b/JiraAnalytics/Common/JiraSearchRequest.go
@@ -1,0 +1,45 @@
+package Common
+
+import (
+	"gitlab.com/surfstudio/infrastructure/spa/spa-backend-com-packages/utils"
+	jsrv "gitlab.com/surfstudio/infrastructure/spa/spa-backend-jira-packages/services"
+	"strconv"
+)
+
+type JiraSearchRequest struct {
+	Wrapped jsrv.RequestConvertible
+	Sprint string
+}
+
+func (req JiraSearchRequest) GetAdditionFields() []jsrv.JiraField {
+	return req.Wrapped.GetAdditionFields()
+}
+
+func (req JiraSearchRequest) GetUseOnlyAdditionalFields() bool {
+	return req.Wrapped.GetUseOnlyAdditionalFields()
+}
+
+// MakeJiraRequest конвертирует структуру в строку JQL запроса.
+func (req JiraSearchRequest) MakeJiraRequest() string {
+
+	result := []string{}
+
+	if len(req.Sprint) != 0 {
+
+		sprintVal := req.Sprint
+
+		if _, err := strconv.Atoi(req.Sprint); err != nil {
+			sprintVal = `"` + sprintVal +`"`
+		}
+
+		result = append(result, "Sprint = " + sprintVal)
+	}
+
+	wrappedStr := req.Wrapped.MakeJiraRequest()
+
+	if len(wrappedStr) != 0 {
+		result = append(result, wrappedStr)
+	}
+
+	return utils.JoinByCharacter(result, " and ", "")
+}

--- a/WhatTimeLeftInitializer.go
+++ b/WhatTimeLeftInitializer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/LastSprint/TeamLeadToolBox/JiraAnalytics"
 	"gitlab.com/surfstudio/infrastructure/spa/spa-backend-com-packages/dbservices/models"
+	"log"
 )
 
 func CreateWhatTimeLeft(user JiraAnalytics.JiraUserModel) (*string, error) {
@@ -18,5 +19,19 @@ func CreateWhatTimeLeft(user JiraAnalytics.JiraUserModel) (*string, error) {
 		return &errMsg, nil
 	}
 
-	return JiraAnalytics.StartWhatTimeLeft(user, models.BoardType(*wtlBoardIdArg), *wtlProjectIdArg)
+	sprint := ""
+
+	if wtlSprintArg != nil {
+		sprint = *wtlSprintArg
+	}
+
+	showIssuesRef := false
+
+	if wtlPrintIssuesRefs != nil {
+		showIssuesRef = *wtlPrintIssuesRefs
+	}
+
+	log.Print(*wtlPrintIssuesRefs)
+
+	return JiraAnalytics.StartWhatTimeLeft(user, models.BoardType(*wtlBoardIdArg), *wtlProjectIdArg, sprint, showIssuesRef)
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 var wtlArgsSet *flag.FlagSet
 var wtlProjectIdArg *string
 var wtlBoardIdArg *string
+var wtlSprintArg *string
+var wtlPrintIssuesRefs *bool
 
 func main() {
 	args := os.Args[1:]
@@ -27,6 +29,8 @@ func main() {
 
 	wtlProjectIdArg = wtlArgsSet.String("projid", "", "Jira Project's ID")
 	wtlBoardIdArg = wtlArgsSet.String("board", "", "Jira Board's Name or ID")
+	wtlSprintArg = wtlArgsSet.String("sprint", "", "Jira Project's sprint ID or name")
+	wtlPrintIssuesRefs = wtlArgsSet.Bool("showIssuesRefs", false, "Print all issues references under the each assignee name")
 
 	config := map[string]string{}
 


### PR DESCRIPTION
Resolved #1 

So now you have to specify a specific sprint you want to analyze. And you can make it by both sprint name or sprint id

And now you can print refs to issues with flag `showIssuesRefs`. It will print the list of issues under each assignee. And if your terminal supported it - you would open this links with `cmd + touch` 
